### PR TITLE
Add Ubuntu 18.04 LTS in the description of script and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Currently, well-supported systems in the stable installer are:
 
   - CentOS/RHEL/Scientific 6 and 7
   - Debian 7, 8, and 9
-  - Ubuntu 14.04 LTS, and 16.04 LTS
+  - Ubuntu 14.04 LTS, and 16.04 LTS, and 18.04 LTS
   
 We strongly recommend you use the latest version of your preferred supported distribution. The latest release gets the most active testing and bug fixing.
 

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -18,13 +18,13 @@
 # License and version
 SERIAL=GPL
 KEY=GPL
-VER=6.0.17
+VER=6.0.18
 vm_version=6
 
 # Currently supported systems:
 supported="    CentOS/RHEL Linux 6 and 7 on x86_64
     Debian 7, 8, and 9, on i386 and amd64
-    Ubuntu 14.04 LTS and 16.04 LTS on i386 and amd64"
+    Ubuntu 14.04 LTS, 16.04 LTS, and 18.04 LTS on i386 and amd64"
 
 log=/root/virtualmin-install.log
 skipyesno=0


### PR DESCRIPTION
I found it confusing to read the script and see that Ubuntu 18.04 LTS was not available for this script. I checked in the commit https://github.com/virtualmin/virtualmin-install/commit/a42e887fa40969325880112a68124df48325a43f and I saw that only the message was deleted because webmin did not support netplan.

I have verified that netplan is already compatible with webmin as reported in http://www.webmin.com/changes.html Version 1.890

Thank you.