### PR TITLE
SSL browser warning: Adjust post-install message

### DIFF
--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -977,7 +977,7 @@ if [ $errors -eq "0" ]; then
   log_success "Installation Complete!"
   log_success "If there were no errors above, Virtualmin should be ready"
   log_success "to configure at https://${hostname}:10000 (or https://${address}:10000)."
-  log_success "You'll receive a security warning in your browser on your first visit."
+  log_success "You may receive a security warning in your browser on your first visit."
 else
   log_warning "The following errors occurred during installation:"
   echo


### PR DESCRIPTION
I just did an install, and a Let's Encrypt cert was created before I logged in. No browser warning. But on some other installs, I do get the error. I don't know what the pattern is, but I propose changing the message to reflect reality. If I am off-base, please just ignore.