### PR TITLE
Dev/support grade b systems

### DIFF
--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -1144,6 +1144,8 @@ if [ $errors -eq "0" ]; then
   log_success "If there were no errors above, Virtualmin should be ready"
   log_success "to configure at https://${hostname}:10000 (or https://${address}:10000)."
   log_success "You may receive a security warning in your browser on your first visit."
+  TIME=$(date +%s)
+  echo "$VER=$TIME" > "/etc/webmin/virtual-server/installed"
 else
   log_warning "The following errors occurred during installation:"
   echo

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -960,8 +960,8 @@ install_with_yum() {
   run_ok "$update" "Checking and installing system packages updates"
 
   # Install core and stack
-  run_ok "$install_group $rhgroup --skip-broken" "Installing dependencies and system packages"
-  run_ok "$install_group $vmgroup --skip-broken" "Installing Virtualmin $vm_version and all related packages"
+  run_ok "$install_group $rhgroup" "Installing dependencies and system packages"
+  run_ok "$install_group $vmgroup" "Installing Virtualmin $vm_version and all related packages"
   if [ $? -ne 0 ]; then
     fatal "Installation failed: $?"
   fi

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -35,7 +35,7 @@ BOLD=$(tput bold)
 
 # Currently supported systems:
 supported="    ${CYANBG}${BLACK}${BOLD}Red Hat Enterprise Linux derivatives${NORMAL}${CYAN}
-      - Alma Linux and Rocky 8 on x86_64
+      - Alma Linux and Rocky 8 and 9 on x86_64
       - CentOS 7 and 8 on x86_64
       - RHEL Linux 7 and 8 on x86_64${NORMAL}
       UNSTABLERHEL
@@ -921,23 +921,23 @@ install_with_yum() {
 
   # Important Perl packages are now hidden in PowerTools repo
   if [ "$os_major_version" -ge 8 ] && [ "$os_type" = "centos" ] || [ "$os_type" = "centos_stream" ] || [ "$os_type" = "rocky" ] || [ "$os_type" = "almalinux" ]; then
-    # Detect PowerTools repo name
-    extra_packages=$(dnf repolist all | grep "^powertools")
-    extra_packages_name="PowerTools"
-    if [ -n "$extra_packages" ]; then
-      extra_packages="powertools"
-    else
-      extra_packages="PowerTools"
-    fi
-
-    # CentOS 9 Stream changed the name to CBR
-    if [ "$os_major_version" -ge 9 ] && [ "$os_type" = "centos_stream" ]; then
+    # Detect CRB/PowerTools repo name
+    if [ "$os_major_version" -ge 9 ]; then
       extra_packages=$(dnf repolist all | grep "^crb")
       if [ -n "$extra_packages" ]; then
         extra_packages="crb"
         extra_packages_name="CRB"
       fi
+    else
+      extra_packages=$(dnf repolist all | grep "^powertools")
+      extra_packages_name="PowerTools"
+      if [ -n "$extra_packages" ]; then
+        extra_packages="powertools"
+      else
+        extra_packages="PowerTools"
+      fi
     fi
+
     run_ok "$install_config_manager --set-enabled $extra_packages" "Enabling $extra_packages_name package repository"
   fi
 

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -60,6 +60,7 @@ usage() {
   printf "  ${YELLOW}--bundle|-b <LAMP|LEMP>${NORMAL} choose bundle to install (defaults to LAMP)\\n"
   printf "  ${YELLOW}--minimal|-m${NORMAL}            install a smaller subset of packages for low-memory/low-resource systems\\n"
   printf "  ${YELLOW}--unstable|-e${NORMAL}           enable support for Grade B systems (Fedora, Oracle)\\n"
+  printf "  ${YELLOW}--no-package-updates|-x${NORMAL} skip installing system package updates\\n"
   printf "  ${YELLOW}--setup|-s${NORMAL}              setup Virtualmin software repositories and exit\\n"
   printf "  ${YELLOW}--hostname|-n${NORMAL}           set fully qualified hostname\\n"
   printf "  ${YELLOW}--force|-f${NORMAL}              assume \"yes\" as answer to all prompts\\n"
@@ -98,6 +99,10 @@ while [ "$1" != "" ]; do
   --unstable | -e)
     shift
     unstable='unstable'
+    ;;
+  --no-package-updates | -x)
+    shift
+    noupdates=1
     ;;
   --setup | -s)
     shift
@@ -860,7 +865,9 @@ fi
 # Install Functions
 install_with_apt() {
   # Install system package upgrades, if any
-  run_ok "$update" "Checking and installing system packages updates"
+  if [ -z "$noupdates" ]; then
+    run_ok "$update" "Checking and installing system packages updates"
+  fi
 
   # Install Webmin/Usermin first, because it needs to be already done
   # for the deps. Then install Virtualmin Core and then Stack packages
@@ -936,7 +943,9 @@ install_with_yum() {
   run_ok "$install_cmd clean all" "Cleaning up software repo metadata"
 
   # Upgrade system packages first
-  run_ok "$update" "Checking and installing system packages updates"
+  if [ -z "$noupdates" ]; then
+    run_ok "$update" "Checking and installing system packages updates"
+  fi
 
   # Install core and stack
   run_ok "$install_group $rhgroup" "Installing dependencies and system packages"

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -264,9 +264,11 @@ if [ "$SERIAL" = "GPL" ]; then
   LOGIN=""
   PRODUCT="GPL"
   repopath="gpl/"
+  packagetype="gpl"
 else
   LOGIN="$SERIAL:$KEY@"
   PRODUCT="Professional"
+  packagetype="pro"
   repopath=""
 fi
 
@@ -751,8 +753,8 @@ install_virtualmin_release() {
       install_config_manager="yum-config-manager"
     fi
 
-    # Install repo file  
-    download "https://software.virtualmin.com/vm/$vm_version/rpm/virtualmin-release-latest.noarch.rpm" "Downloading Virtualmin $vm_version release package"
+    # Install release file
+    download "https://software.virtualmin.com/vm/$vm_version/rpm/virtualmin-$packagetype-release.noarch.rpm" "Downloading Virtualmin $vm_version release package"
     run_ok "rpm -U --replacepkgs --quiet virtualmin-release-latest.noarch.rpm" "Installing Virtualmin release package"
 
     rpm --import RPM-GPG-KEY-virtualmin-$vm_version

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -754,7 +754,7 @@ install_virtualmin_release() {
     fi
 
     # Install release file
-    download "https://software.virtualmin.com/vm/$vm_version/rpm/virtualmin-$packagetype-release.noarch.rpm" "Downloading Virtualmin $vm_version release package"
+    download "https://${LOGIN}$upgrade_virtualmin_host/vm/$vm_version/rpm/virtualmin-$packagetype-release.noarch.rpm" "Downloading Virtualmin $vm_version release package"
     run_ok "rpm -U --replacepkgs --quiet virtualmin-release-latest.noarch.rpm" "Installing Virtualmin release package"
 
     rpm --import RPM-GPG-KEY-virtualmin-$vm_version

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -766,9 +766,9 @@ install_virtualmin_release() {
     fi
     
     # Configure repo file  
-    log_debug "Setting up $os_real Virtualmin repositories .."
+    log_debug "Setting up $os_real Virtualmin $vm_version repositories .."
     printf "[virtualmin]\\n" >$rhel_derivative_repo_file
-    printf "name=Virtualmin for $os_real \$releasever - \$basearch\\n" >>$rhel_derivative_repo_file
+    printf "name=Virtualmin $vm_version Packages for $os_real \$releasever - \$basearch\\n" >>$rhel_derivative_repo_file
     printf "baseurl=https://${LOGIN}$upgrade_virtualmin_host/vm/$vm_version/${repopath}${rhel_derivative_variant}/$rhel_derivative_base_version/\$basearch/\\n" >>$rhel_derivative_repo_file
     printf "enabled=1\\n" >>$rhel_derivative_repo_file
     printf "gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-virtualmin-$vm_version\\n" >>$rhel_derivative_repo_file
@@ -777,8 +777,8 @@ install_virtualmin_release() {
       printf "exclude=$excluded\\n" >>$rhel_derivative_repo_file
     fi
     printf "\\n" >>$rhel_derivative_repo_file
-    printf "[virtualmin-neutral]\\n" >>$rhel_derivative_repo_file
-    printf "name=Virtualmin Neutral for $os_real \$releasever\\n" >>$rhel_derivative_repo_file
+    printf "[virtualmin-universal]\\n" >>$rhel_derivative_repo_file
+    printf "name=Virtualmin $vm_version Neutral Packages for $os_real \$releasever\\n" >>$rhel_derivative_repo_file
     printf "baseurl=https://${LOGIN}$upgrade_virtualmin_host/vm/$vm_version/${repopath}universal/\\n" >>$rhel_derivative_repo_file
     printf "enabled=1\\n" >>$rhel_derivative_repo_file
     printf "gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-virtualmin-$vm_version\\n" >>$rhel_derivative_repo_file

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -752,40 +752,9 @@ install_virtualmin_release() {
       install_group="yum -y --quiet groupinstall --setopt=group_package_types=mandatory,default"
       install_config_manager="yum-config-manager"
     fi
-    
-    # Setup repos
-    rhel_derivative_repo_file="/etc/yum.repos.d/virtualmin.repo"
-    rhel_derivative_variant="$os_type"
-    rhel_derivative_base_version="$os_major_version"
 
-    # Oracle mod
-    if [ "$os_type" = "ol" ]; then
-      rhel_derivative_variant='rhel'
-    fi
-
-    # Fedora mod
-    if [ "$os_type" = "fedora" ]; then
-      rhel_derivative_variant="rhel"
-      rhel_derivative_base_version=8
-      excluded="jailkit"
-      removeunused="wbm-jailkit"
-      
-      log_debug "Installing distro ($os_real) specific packages .."
-      run_ok "$install cronie" "Installing distro specific packages"
-    fi
-
-    # CentOS Stream mods
-    if [ "$os_type" = "centos_stream" ]; then
-      rhel_derivative_variant="centos"
-      if [ "$os_major_version" -ge 9 ]; then
-        rhel_derivative_base_version=8
-        log_debug "Installing distro ($os_real) specific packages .."
-        run_ok "$install postfix" "Installing distro specific packages"
-      fi
-    fi
-
-    # Configure repo file  
-    download "https://${LOGIN}$upgrade_virtualmin_host/vm/${vm_version}/${repopath}${rhel_derivative_variant}/${rhel_derivative_base_version}/${arch}/virtualmin-release-latest.noarch.rpm" "Downloading Virtualmin $vm_version release package"
+    # Install repo file  
+    download "https://software.virtualmin.com/vm/$vm_version/rpm/virtualmin-release-latest.noarch.rpm" "Downloading Virtualmin $vm_version release package"
     run_ok "rpm -U --replacepkgs --quiet virtualmin-release-latest.noarch.rpm" "Installing Virtualmin release package"
 
     rpm --import RPM-GPG-KEY-virtualmin-$vm_version
@@ -1051,11 +1020,6 @@ run_ok "$install_updates" "Installing Virtualmin $vm_version related packages up
 if [ "$?" != "0" ]; then
   errorlist="${errorlist}  ${YELLOW}◉${NORMAL} Installing updates returned an error.\\n"
   errors=$((errors + 1))
-fi
-
-# Clean up un-used packages, if any
-if [ -n "$removeunused" ]; then
-  run_ok "$remove $removeunused" "Cleaning up un-used modules"
 fi
 
 # Reap any clingy processes (like spinner forks)

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -752,9 +752,6 @@ install_virtualmin_release() {
     # Install release file
     download "https://${LOGIN}$upgrade_virtualmin_host/vm/$vm_version/rpm/virtualmin-$packagetype-release.noarch.rpm" "Downloading Virtualmin $vm_version release package"
     run_ok "rpm -U --replacepkgs --quiet virtualmin-$packagetype-release.noarch.rpm" "Installing Virtualmin release package"
-
-    rpm --import RPM-GPG-KEY-virtualmin-$vm_version
-    rpm --import RPM-GPG-KEY-webmin
     ;;
   debian | ubuntu)
     case "$os_type" in

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -751,7 +751,7 @@ install_virtualmin_release() {
 
     # Install release file
     download "https://${LOGIN}$upgrade_virtualmin_host/vm/$vm_version/rpm/virtualmin-$packagetype-release.noarch.rpm" "Downloading Virtualmin $vm_version release package"
-    run_ok "rpm -U --replacepkgs --quiet virtualmin-release-latest.noarch.rpm" "Installing Virtualmin release package"
+    run_ok "rpm -U --replacepkgs --quiet virtualmin-$packagetype-release.noarch.rpm" "Installing Virtualmin release package"
 
     rpm --import RPM-GPG-KEY-virtualmin-$vm_version
     rpm --import RPM-GPG-KEY-webmin

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -722,7 +722,7 @@ install_virtualmin_release() {
       fi
       ;;
     fedora)
-      if [ "$os_version" -lt 36 ] || [ -z "$unstable" ] && [ "$os_type" = "fedora" ]  ; then
+      if [ "$os_version" -lt 35 ] || [ -z "$unstable" ] && [ "$os_type" = "fedora" ]  ; then
         printf "${RED}${os_real} ${os_version} is not supported by this installer.${NORMAL}\\n"
         exit 1
       fi
@@ -960,8 +960,8 @@ install_with_yum() {
   run_ok "$update" "Checking and installing system packages updates"
 
   # Install core and stack
-  run_ok "$install_group $rhgroup" "Installing dependencies and system packages"
-  run_ok "$install_group $vmgroup" "Installing Virtualmin $vm_version and all related packages"
+  run_ok "$install_group $rhgroup --skip-broken" "Installing dependencies and system packages"
+  run_ok "$install_group $vmgroup --skip-broken" "Installing Virtualmin $vm_version and all related packages"
   if [ $? -ne 0 ]; then
     fatal "Installation failed: $?"
   fi

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -18,7 +18,7 @@
 # License and version
 SERIAL=GPL
 KEY=GPL
-VER=7.0.0-RC5
+VER=7.0.0-beta
 vm_version=7
 upgrade_virtualmin_host=software.virtualmin.com
 

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -488,12 +488,13 @@ uninstall() {
     echo "I don't know how to uninstall on this operating system."
     ;;
   esac
-  echo 'Removing nameserver 127.0.0.1 from /etc/resolv.conf'
-  sed -i '/nameserver 127.0.0.1/g' /etc/resolv.conf
-  echo 'Removing virtualmin repo configuration'
+  echo 'Removing Virtualmin repo configuration'
   remove_virtualmin_release
-  echo "Removing /etc/virtualmin-license, if it exists."
-  rm /etc/virtualmin-license
+  virtualmin_license_file="/etc/virtualmin-license"
+  if [ -f "$virtualmin_license_file" ]; then
+    echo "Removing Virtualmin license"
+    rm "$virtualmin_license_file"
+  fi
   echo "Done.  There's probably quite a bit of related packages and such left behind"
   echo "but all of the Virtualmin-specific packages have been removed."
   exit 0

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -546,7 +546,7 @@ EOF
   Exit and re-run this script with ${CYAN}--help${NORMAL} flag to see available options.
 
 EOF
-exit
+
   printf " Continue? (y/n) "
   if ! yesno; then
     exit

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -873,10 +873,6 @@ install_with_apt() {
   # Install Webmin first, because it needs to be already done for the deps
   run_ok "$install webmin" "Installing Webmin"
   run_ok "$install usermin" "Installing Usermin"
-  if [ $bundle = 'LEMP' ]; then
-    run_ok "$install nginx-common" "Installing nginx-common"
-    sed -i 's/listen \[::\]:80 default_server;/#listen \[::\]:80 default_server;/' /etc/nginx/sites-available/default
-  fi
   run_ok "$install ${debvmpackages}" "Installing Virtualmin $vm_version related packages"
   run_ok "$install $deps" "Installing $rhgrouptext"
   if [ $? -ne 0 ]; then

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -735,7 +735,6 @@ install_virtualmin_release() {
     package_type="rpm"
     if command -pv dnf 1>/dev/null 2>&1; then
       install="dnf -y install"
-      remove="dnf -y remove"
       install_cmd="dnf"
       install_group="dnf -y --quiet group install --setopt=group_package_types=mandatory,default"
       install_config_manager="dnf config-manager"
@@ -744,7 +743,6 @@ install_virtualmin_release() {
       fi
     else
       install="/usr/bin/yum -y install"
-      remove="/usr/bin/yum -y remove"
       install_cmd="/usr/bin/yum"
       if [ "$os_major_version" -ge 7 ]; then
         run_ok "yum --quiet groups mark convert" "Updating yum Groups"

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -785,30 +785,11 @@ install_virtualmin_release() {
     fi
 
     # Configure repo file  
-    log_debug "Setting up $os_real Virtualmin $vm_version repositories .."
-    printf "[virtualmin]\\n" >$rhel_derivative_repo_file
-    printf "name=Virtualmin $vm_version Packages for $os_real \$releasever - \$basearch\\n" >>$rhel_derivative_repo_file
-    printf "baseurl=https://${LOGIN}$upgrade_virtualmin_host/vm/$vm_version/${repopath}${rhel_derivative_variant}/$rhel_derivative_base_version/\$basearch/\\n" >>$rhel_derivative_repo_file
-    printf "enabled=1\\n" >>$rhel_derivative_repo_file
-    printf "gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-virtualmin-$vm_version\\n" >>$rhel_derivative_repo_file
-    printf "gpgcheck=1\\n" >>$rhel_derivative_repo_file
-    if [ -n "$excluded" ]; then
-      printf "exclude=$excluded\\n" >>$rhel_derivative_repo_file
-    fi
-    printf "\\n" >>$rhel_derivative_repo_file
-    printf "[virtualmin-universal]\\n" >>$rhel_derivative_repo_file
-    printf "name=Virtualmin $vm_version Neutral Packages for $os_real \$releasever\\n" >>$rhel_derivative_repo_file
-    printf "baseurl=https://${LOGIN}$upgrade_virtualmin_host/vm/$vm_version/${repopath}universal/\\n" >>$rhel_derivative_repo_file
-    printf "enabled=1\\n" >>$rhel_derivative_repo_file
-    printf "gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-virtualmin-$vm_version\\n" >>$rhel_derivative_repo_file
-    printf "gpgcheck=1\\n" >>$rhel_derivative_repo_file
-    run_ok "echo >>$rhel_derivative_repo_file" "Setting up Virtualmin repositories"
+    download "https://${LOGIN}$upgrade_virtualmin_host/vm/${vm_version}/${repopath}${rhel_derivative_variant}/${rhel_derivative_base_version}/${arch}/virtualmin-release-latest.noarch.rpm" "Downloading Virtualmin $vm_version release package"
+    run_ok "rpm -U --replacepkgs --quiet virtualmin-release-latest.noarch.rpm" "Installing Virtualmin release package"
 
-    log_debug "Installing Webmin and Virtualmin package signing keys .."
-    download "https://$upgrade_virtualmin_host/lib/RPM-GPG-KEY-virtualmin-$vm_version" "Downloading Virtualmin $vm_version key"
-    run_ok "rpm --import RPM-GPG-KEY-virtualmin-$vm_version" "Installing Virtualmin $vm_version key"
-    download "https://$upgrade_virtualmin_host/lib/RPM-GPG-KEY-webmin" "Downloading Webmin key"
-    run_ok "rpm --import RPM-GPG-KEY-webmin" "Installing Webmin key"
+    rpm --import RPM-GPG-KEY-virtualmin-$vm_version
+    rpm --import RPM-GPG-KEY-webmin
     ;;
   debian | ubuntu)
     case "$os_type" in

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -279,7 +279,7 @@ else
   LOGIN="$SERIAL:$KEY@"
   PRODUCT="Professional"
   packagetype="pro"
-  repopath=""
+  repopath="pro/"
 fi
 
 # Virtualmin-provided packages
@@ -783,31 +783,10 @@ install_virtualmin_release() {
     package_type="deb"
     if [ "$os_type" = "ubuntu" ]; then
       deps="$ubudeps"
-      case "$os_version" in
-      18.04*)
-        repos="virtualmin-bionic virtualmin-universal"
-        ;;
-      20.04*)
-        repos="virtualmin-focal virtualmin-universal"
-        ;;
-      22.04*)
-        repos="virtualmin-jammy virtualmin-universal"
-        ;;
-      esac
     else
       deps="$debdeps"
-      case "$os_version" in
-      9*)
-        repos="virtualmin-stretch virtualmin-universal"
-        ;;
-      10*)
-        repos="virtualmin-buster virtualmin-universal"
-        ;;
-      11*)
-        repos="virtualmin-bullseye virtualmin-universal"
-        ;;
-      esac
     fi
+    repos="virtualmin"
     log_debug "apt-get repos: ${repos}"
     if [ -z "$repos" ]; then # Probably unstable with no version number
       log_fatal "No repos available for this OS. Are you running unstable/testing?"

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -18,7 +18,7 @@
 # License and version
 SERIAL=GPL
 KEY=GPL
-VER=7.0.0-beta
+VER=7.0.0-RC6
 vm_version=7
 upgrade_virtualmin_host=software.virtualmin.com
 

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -135,11 +135,11 @@ if [ -z "$setup_only" ]; then
 
   # Check if current time
   # is not older than
-  # April 2, 2022
-  TIMEBASE=1651363200
+  # May 16, 2022
+  TIMEBASE=1652691600
   TIME=$(date +%s)
   if [ "$TIME" -lt "$TIMEBASE" ]; then
-    echo "  Syncing system time .."
+    echo "  Force-syncing system time .."
 
     # Try to sync time automatically first
     if systemctl restart chronyd 1>/dev/null 2>&1; then
@@ -155,11 +155,21 @@ if [ -z "$setup_only" ]; then
       exit
     fi
     echo "  .. done"
+  # Graceful sync
+  else
+    echo "  Syncing system time .."
+    if systemctl restart chronyd 1>/dev/null 2>&1; then
+      sleep 2
+      echo "  .. done"
+    elif systemctl restart systemd-timesyncd 1>/dev/null 2>&1; then
+      echo "  .. done"
+      sleep 2
+    fi
   fi
 
   # Update all system packages first
-  echo "  Checking for an update for a set of CA certificates .."
   printf "Checking for an update for a set of CA certificates ..\\n" >>$log
+  echo "  Updating CA certificates .."
   if [ -x /usr/bin/dnf ]; then
     dnf -y update ca-certificates >>$log 2>&1
   elif [ -x /usr/bin/yum ]; then

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -22,24 +22,6 @@ VER=7.0.0-RC6
 vm_version=7
 upgrade_virtualmin_host=software.virtualmin.com
 
-# Currently supported systems:
-supported="    Red Hat Enterprise Linux derivatives
-      - Alma Linux and Rocky 8 on x86_64
-      - CentOS 7 and 8 on x86_64
-      - RHEL Linux 7 and 8 on x86_64
-
-    Debian Linux derivatives
-      - Ubuntu 20.04 LTS and 22.04 LTS on i386 and amd64
-      - Debian 10 and 11 on i386 and amd64"
-
-unstable_supported="    Grade B systems
-      Red Hat Enterprise Linux derivatives
-        - Fedora Server 36 and above
-        - Oracle Linux 8"
-
-log=/root/virtualmin-install.log
-skipyesno=0
-
 # Print usage info, if --help, set mode, etc.
 # Temporary colors
 RED="$(tput setaf 1)"
@@ -48,6 +30,25 @@ CYAN="$(tput setaf 6)"
 BLACK="$(tput setaf 16)"
 NORMAL="$(tput sgr0)"
 GREEN=$(tput setaf 2)
+CYANBG=$(tput setab 6)
+BOLD=$(tput bold)
+
+# Currently supported systems:
+supported="    ${CYANBG}${BLACK}${BOLD}Red Hat Enterprise Linux derivatives${NORMAL}${CYAN}
+      - Alma Linux and Rocky 8 on x86_64
+      - CentOS 7 and 8 on x86_64
+      - RHEL Linux 7 and 8 on x86_64${NORMAL}
+      UNSTABLERHEL
+    ${CYANBG}${BLACK}${BOLD}Debian Linux derivatives${NORMAL}${CYAN}
+      - Ubuntu 20.04 LTS and 22.04 LTS on i386 and amd64
+      - Debian 10 and 11 on i386 and amd64${NORMAL}"
+
+unstable_rhel="${YELLOW}- Fedora Server 36 on x86_64
+      - Oracle Linux 8 on x86_64
+      ${NORMAL}"
+
+log=/root/virtualmin-install.log
+skipyesno=0
 
 # Set defaults
 bundle='LAMP' # Other option is LEMP
@@ -62,7 +63,7 @@ usage() {
   printf "  ${YELLOW}--help|-h${NORMAL}               display this help and exit\\n"
   printf "  ${YELLOW}--bundle|-b <LAMP|LEMP>${NORMAL} choose bundle to install (defaults to LAMP)\\n"
   printf "  ${YELLOW}--minimal|-m${NORMAL}            install a smaller subset of packages for low-memory/low-resource systems\\n"
-  printf "  ${YELLOW}--unstable|-e${NORMAL}           enable support for grade B systems\\n"
+  printf "  ${YELLOW}--unstable|-e${NORMAL}           enable support for Grade B systems (Fedora, Oracle)\\n"
   printf "  ${YELLOW}--setup|-s${NORMAL}              setup Virtualmin software repositories and exit\\n"
   printf "  ${YELLOW}--hostname|-n${NORMAL}           set fully qualified hostname\\n"
   printf "  ${YELLOW}--force|-f${NORMAL}              assume \"yes\" as answer to all prompts\\n"
@@ -525,11 +526,13 @@ install_msg() {
   The systems currently supported by install script are:
 
 EOF
-  echo "${CYAN}$supported${NORMAL}"
+  supported_all=$supported
   if [ -n "$unstable" ]; then
-      echo
-      echo "${YELLOW}$unstable_supported${NORMAL}"
+    supported_all="${supported_all/UNSTABLERHEL/$unstable_rhel}"
+  else
+    supported_all="${supported_all/UNSTABLERHEL/}"
   fi
+  echo "$supported_all"
   cat <<EOF
 
   If your OS/version/arch is not listed, installation ${RED}will fail${NORMAL}. More

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -71,33 +71,6 @@ while [ "$1" != "" ]; do
     usage
     exit 0
     ;;
-  --uninstall | -u)
-    shift
-    mode="uninstall"
-    ;;
-  --force | -f | --yes | -y)
-    shift
-    skipyesno=1
-    ;;
-  --hostname | -n)
-    shift
-    forcehostname=$1
-    shift
-    ;;
-  --verbose | -v)
-    shift
-    VERBOSE=1
-    ;;
-  --setup | -s)
-    shift
-    setup_only=1
-    mode='setup'
-    break
-    ;;
-  --minimal | -m)
-    shift
-    mode='minimal'
-    ;;
   --bundle | -b)
     shift
     case "$1" in
@@ -114,6 +87,37 @@ while [ "$1" != "" ]; do
       exit 1
       ;;
     esac
+    ;;
+  --minimal | -m)
+    shift
+    mode='minimal'
+    ;;
+  --unstable | -e)
+    shift
+    unstable='unstable'
+    ;;
+  --setup | -s)
+    shift
+    setup_only=1
+    mode='setup'
+    break
+    ;;
+  --hostname | -n)
+    shift
+    forcehostname=$1
+    shift
+    ;;
+  --force | -f | --yes | -y)
+    shift
+    skipyesno=1
+    ;;
+  --verbose | -v)
+    shift
+    VERBOSE=1
+    ;;
+  --uninstall | -u)
+    shift
+    mode="uninstall"
     ;;
   *)
     printf "Unrecognized option: $1\\n\\n"

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -18,7 +18,7 @@
 # License and version
 SERIAL=GPL
 KEY=GPL
-VER=7.0.0-RC6
+VER=7.0.0-RC7
 vm_version=7
 upgrade_virtualmin_host=software.virtualmin.com
 

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -870,11 +870,10 @@ fi
 
 # Install Functions
 install_with_apt() {
-  # Install Webmin first, because it needs to be already done for the deps
-  run_ok "$install webmin" "Installing Webmin"
-  run_ok "$install usermin" "Installing Usermin"
-  run_ok "$install ${debvmpackages}" "Installing Virtualmin $vm_version related packages"
-  run_ok "$install $deps" "Installing $rhgrouptext"
+  # Install Webmin/Usermin first, because it needs to be already done
+  # for the deps. Then install Virtualmin Core and then Stack packages
+  # Do it all in one go for the nicer UI
+  run_ok "$install webmin && $install usermin && $install $debvmpackages && $install $deps" "Installing Virtualmin $vm_version and all related packages"
   if [ $? -ne 0 ]; then
     log_warning "apt-get seems to have failed. Are you sure your OS and version is supported?"
     log_warning "https://www.virtualmin.com/os-support"
@@ -988,7 +987,7 @@ fi
 
 # We want to make sure we're running our version of packages if we have
 # our own version.  There's no good way to do this, but we'll
-run_ok "$install_updates" "Installing Virtualmin $vm_version related packages updates"
+run_ok "$install_updates" "Installing Virtualmin $vm_version and all related packages updates"
 if [ "$?" != "0" ]; then
   errorlist="${errorlist}  ${YELLOW}◉${NORMAL} Installing updates returned an error.\\n"
   errors=$((errors + 1))

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -174,7 +174,7 @@ if [ -z "$setup_only" ]; then
 fi
 # loop until we've got a Perl or until we can't try any more
 while true; do
-  perl="$(command -v perl 2>/dev/null)"
+  perl="$(command -pv perl 2>/dev/null)"
   if [ -z "$perl" ]; then
     if [ -x /usr/bin/perl ]; then
       perl=/usr/bin/perl
@@ -445,9 +445,9 @@ uninstall() {
 
   # This is a crummy way to detect package manager...but going through
   # half the installer just to get here is even crummier.
-  if command -v rpm 1>/dev/null 2>&1; then
+  if command -pv rpm 1>/dev/null 2>&1; then
     package_type=rpm
-  elif command -v dpkg 1>/dev/null 2>&1; then
+  elif command -pv dpkg 1>/dev/null 2>&1; then
     package_type=deb
   fi
 
@@ -732,7 +732,7 @@ install_virtualmin_release() {
       fi
     fi
     package_type="rpm"
-    if command -v dnf 1>/dev/null 2>&1; then
+    if command -pv dnf 1>/dev/null 2>&1; then
       install="dnf -y install"
       remove="dnf -y remove"
       install_cmd="dnf"


### PR DESCRIPTION
I suggest dropping `virtualmin-release-latest` package and configure the repo for all RHEL systems on the installer, the same way we do it for Ubuntu and Debian.

This also won't create a wrong impression that installing `virtualmin-release-latest` and later running `dnf install wbm-virtual-server` is equivalent to installing Virtualmin.

Fedora installation and Oracle will work but only if `--unstable` param is used, and if so, it will add extra text in yellow to supported systems list:

<img width="559" alt="image" src="https://user-images.githubusercontent.com/4426533/168364771-44d71041-7ccc-4975-bddb-9d9310dcd7a5.png">
