### PR TITLE
Allow `--skip-broken` as vendors tend to break our install!

### DIFF
--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -773,7 +773,7 @@ install_virtualmin_release() {
       install="dnf -y install"
       update="dnf -y update"
       install_cmd="dnf"
-      install_group="dnf -y --quiet group install --setopt=group_package_types=mandatory,default"
+      install_group="dnf -y --quiet --skip-broken group install --setopt=group_package_types=mandatory,default"
       install_config_manager="dnf config-manager"
       # Do not use package manager when fixing repos
       if [ -z "$setup_only" ]; then
@@ -789,7 +789,7 @@ install_virtualmin_release() {
           run_ok "yum --quiet groups mark convert" "Updating groups metadata"
         fi
       fi
-      install_group="yum -y --quiet groupinstall --setopt=group_package_types=mandatory,default"
+      install_group="yum -y --quiet --skip-broken groupinstall --setopt=group_package_types=mandatory,default"
       install_config_manager="yum-config-manager"
     fi
 

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -42,7 +42,19 @@ supported="    ${CYANBG}${BLACK}${BOLD}Red Hat Enterprise Linux derivatives${NOR
       - Ubuntu 20.04 LTS and 22.04 LTS on i386 and amd64
       - Debian 10 and 11 on i386 and amd64${NORMAL}"
 
+# Store new log each time
 log=/root/virtualmin-install.log
+if [ -e "$log" ]; then
+  while true; do
+    logcnt=$((logcnt+1))
+    logold="$log.$logcnt"
+    if [ ! -e "$logold" ]; then
+      mv $log $logold
+      break
+    fi
+  done
+fi
+
 skipyesno=0
 
 # Set defaults


### PR DESCRIPTION
It seems that we actually need to allow `--skip-broken` as vendors tend to break our install (time after time)! For example, at the moment Alma 9 and Rocky 9 with EPEL 9 enabled simply break our whole install because `awstats` package is available but has a broken dependency. This is a blocker for a user to continue with Virtualmin install.

<img width="1230" alt="image" src="https://user-images.githubusercontent.com/4426533/182412340-6342eecc-3ca7-4dcb-9832-14170038fb19.png">

Skipped packages are logged to Virtualmin installation log file. Also, I will patch Virtualmin Config, which will show an orange box if Awstats is not available and it will also disable Virtualmin Awstats module for Virtualmin check to pass with no errors.

Doing this will provide smoother experience across distros, including Grade B systems, like broken `jailkit` package issue on Fedora.

This must never happen in practice but if upstream packages/repos have issues they will be just skipped without fatal errors letting a user not to blame us and safely install core and working system. As that awstats package is not essential and can be installed later.
