### PR TITLE
fix root user checking on zh systems

### DIFF
--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -757,8 +757,7 @@ download() {
 }
 
 # Only root can run this
-id | grep -i "id=0(" >/dev/null
-if [ "$?" != "0" ]; then
+if [ $(id -u) -ne 0 ]; then
   uname -a | grep -i CYGWIN >/dev/null
   if [ "$?" != "0" ]; then
     fatal "${RED}Fatal:${NORMAL} The Virtualmin install script must be run as root"

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -757,7 +757,7 @@ download() {
 }
 
 # Only root can run this
-id | grep -i "uid=0(" >/dev/null
+id | grep -i "id=0(" >/dev/null
 if [ "$?" != "0" ]; then
   uname -a | grep -i CYGWIN >/dev/null
   if [ "$?" != "0" ]; then


### PR DESCRIPTION
Log in root user on English systems, `id` will output `uid=0(root) gid=0(root) groups=0(root)`, that's OK.
But, on Chinese, `id` will output `用户id=0(root) 组id=0(root) 组=0(root)`, making the script thinks it's not running as root.
This PR changes this to check if `id -u` is `0`.