### PR TITLE
Add openSUSE support

### DIFF
--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -1249,7 +1249,6 @@ install_with_yum() {
         virtualmin_group_missing=$(echo "$virtualmin_group_missing" | sed 's/fail2ban-firewalld/fail2ban/g')
         # The package mod_fcgid is named apache2-mod_fcgid in openSUSE
         virtualmin_group_missing=$(echo "$virtualmin_group_missing" | sed 's/mod_fcgid/apache2-mod_fcgid/g')
-        echo $virtualmin_group_missing
         # AppArmor should either be configured to allow /var/php-fpm for
         # PHP-FPM sockets or disabled completely
         systemctl stop apparmor.service

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# shellcheck disable=SC2059 disable=SC2181 disable=SC2154 disable=SC2317 disable=SC3043 disable=SC2086 disable=SC2039 disable=SC2034
+# shellcheck disable=SC2059 disable=SC2181 disable=SC2154 disable=SC2317 disable=SC3043 disable=SC2086 disable=SC2039 disable=SC2034 disable=SC2089 disable=SC2090
 # virtualmin-install.sh
 # Copyright 2005-2023 Virtualmin, Inc.
 # Simple script to grab the virtualmin-release and virtualmin-base packages.

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -1290,7 +1290,7 @@ fi
 
 # We want to make sure we're running our version of packages if we have
 # our own version.  There's no good way to do this, but we'll
-run_ok "$install_updates" "Installing Virtualmin $vm_version and all related packages updates"
+run_ok "$install_updates" "Installing Virtualmin $vm_version related packages updates"
 if [ "$?" != "0" ]; then
   errorlist="${errorlist}  ${YELLOW}◉${NORMAL} Installing updates returned an error.\\n"
   errors=$((errors + 1))

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -826,6 +826,9 @@ log_debug "virtualmin-install.sh version: $VER"
 if [ -z "$setup_only" ]; then
   log_debug "Checking for fully qualified hostname .."
   name="$(hostname -f)"
+  if [ $? -ne 0 ]; then
+    name=$(hostnamectl --static)
+  fi
   if [ -n "$forcehostname" ]; then
     set_hostname "$forcehostname"
   elif ! is_fully_qualified "$name"; then

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -1265,6 +1265,8 @@ install_with_yum() {
       } >> "$log" 2>&1
     }
     run_ok "opensuse_poststack" "Installing Virtualmin $vm_version missing stack packages"
+    # Don't show false positively skipped packages
+    noskippedpackagesforce=1
     # Fix to skip configuring AWStats as it's not available in openSUSE
     virtualmin_config_system_excludes=" --exclude AWStats"
   fi
@@ -1311,7 +1313,7 @@ yum_check_skipped() {
       skippedpackagesnum=$((skippedpackagesnum+1))
     fi
   done < "$log"
-  if [ "$skippedpackages" != "" ]; then
+  if [ -z "$noskippedpackagesforce" ] && [ "$skippedpackages" != "" ]; then
     if [ "$skippedpackagesnum" != 1 ]; then
       ts="s"
     fi

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -923,11 +923,12 @@ install_virtualmin_release() {
     fi
     package_type="rpm"
     if command -pv dnf 1>/dev/null 2>&1; then
-      install="dnf -y install"
-      update="dnf -y update"
       install_cmd="dnf"
-      install_group="dnf -y --quiet --skip-broken group install --setopt=group_package_types=mandatory,default"
-      install_config_manager="dnf config-manager"
+      install="$install_cmd -y install"
+      update="$install_cmd -y update"
+      install_group_opts="-y --quiet --skip-broken group install --setopt=group_package_types=mandatory,default"
+      install_group="$install_cmd $install_group_opts"
+      install_config_manager="$install_cmd config-manager"
       # Do not use package manager when fixing repos
       if [ -z "$setup_only" ]; then
         run_ok "$install dnf-plugins-core" "Installing core plugins for package manager"

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -1224,6 +1224,52 @@ install_with_yum() {
     fatal "Installation failed: $rs"
   fi
 
+  # Work around openSUSE pitfalls
+  if [ "$os_type" = "opensuse-leap" ]; then
+    opensuse_poststack() {
+      {
+        # Install Virtualmin Config package manually
+        # as it currently fails with false positive error
+        package_virtualmin_config=$(dnf download virtualmin-config)
+        package_virtualmin_config_name=$(echo "$package_virtualmin_config" | grep -o 'virtualmin-config[^ ]*.rpm')
+        rpm -U --nodeps --replacepkgs --replacefiles --quiet $package_virtualmin_config_name
+        # Create symlink to known @INC to where Virtualmin Config is actually is
+        ln -sf /usr/share/perl5/vendor_perl/Virtualmin /usr/lib/perl5/site_perl
+        # Remove downloaded package
+        rm -f $package_virtualmin_config_name
+        # Now check which packages are missing and install them manually using package manager
+        install_group_opts_loud=$(echo $install_group_opts | sed 's/ --quiet//g')
+        virtualmin_group_missing_cmd="$install_cmd $install_group_opts_loud $rhgroup"
+        virtualmin_group_missing_try=$(eval $virtualmin_group_missing_cmd 2>&1)
+        # Extract missing package list
+        virtualmin_group_missing=$(echo "$virtualmin_group_missing_try" | grep -o '"[^"]\+"' | tr -d '"' | tr '\n' ' ')
+        # PHP packages are actually named php8-* in openSUSE
+        virtualmin_group_missing=$(echo "$virtualmin_group_missing" | sed 's/php-/php8-/g')
+        # The package fail2ban-firewalld is named fail2ban in openSUSE
+        virtualmin_group_missing=$(echo "$virtualmin_group_missing" | sed 's/fail2ban-firewalld/fail2ban/g')
+        # The package mod_fcgid is named apache2-mod_fcgid in openSUSE
+        virtualmin_group_missing=$(echo "$virtualmin_group_missing" | sed 's/mod_fcgid/apache2-mod_fcgid/g')
+        echo $virtualmin_group_missing
+        # AppArmor should either be configured to allow /var/php-fpm for
+        # PHP-FPM sockets or disabled completely
+        systemctl stop apparmor.service
+        systemctl disable apparmor.service
+        systemctl mask apparmor.service
+        # Swap pre-installed posfix for postfix-bdb-lmdb
+        $install_cmd -y swap --allowerasing postfix postfix-bdb-lmdb
+        # Install missing packages that we extracted earlier
+        $install --skip-broken $virtualmin_group_missing cyrus-sasl-saslauthd
+        # There is no AWStats package in openSUSE
+        $install_cmd -y remove wbm-virtualmin-awstats
+        # Add allow_vendor_change=True to /etc/dnf/dnf.conf unless it's already there
+        grep -qxF 'allow_vendor_change=True' /etc/dnf/dnf.conf || echo "allow_vendor_change=True" >> /etc/dnf/dnf.conf
+      } >> "$log" 2>&1
+    }
+    run_ok "opensuse_poststack" "Installing Virtualmin $vm_version missing stack packages"
+    # Fix to skip configuring AWStats as it's not available in openSUSE
+    virtualmin_config_system_excludes=" --exclude AWStats"
+  fi
+
   return 0
 }
 

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -327,7 +327,7 @@ log_fatal() {
 
 remove_virtualmin_release() {
   case "$os_type" in
-  "fedora" | "centos" | "centos_stream" | "rhel" | "rocky" | "almalinux" | "ol" | "cloudlinux" | "amzn")
+  "fedora" | "centos" | "centos_stream" | "rhel" | "rocky" | "almalinux" | "ol" | "cloudlinux" | "amzn" | "opensuse-leap")
     rm -f /etc/yum.repos.d/virtualmin.repo
     rm -f /etc/pki/rpm-gpg/RPM-GPG-KEY-virtualmin-*
     rm -f /etc/pki/rpm-gpg/RPM-GPG-KEY-webmin
@@ -515,6 +515,7 @@ EOF
      - CentOS Stream 8 and 9 on x86_64\\n \
      - Oracle Linux 8 and 9 on x86_64\\n \
      - CloudLinux 8 and 9 on x86_64\\n \
+     - openSUSE Server 15 on x86_64\\n \
           ${NORMAL}"
     unstable_deb="${YELLOW}- Kali Linux Rolling on x86_64\\n \
           ${NORMAL}"
@@ -855,7 +856,7 @@ install_virtualmin_release() {
   # Grab virtualmin-release from the server
   log_debug "Configuring package manager for ${os_real} ${os_version} .."
   case "$os_type" in
-  rhel | centos | centos_stream | rocky | almalinux | ol | cloudlinux | amzn | fedora)
+  rhel | centos | centos_stream | rocky | almalinux | ol | cloudlinux | amzn | fedora | opensuse-leap)
     case "$os_type" in
     rhel | centos | centos_stream)
       if [ "$os_type" = "centos_stream" ]; then
@@ -886,9 +887,9 @@ install_virtualmin_release() {
         exit 1
       fi
       ;;
-    amzn)
-      if [ "$os_version" -lt 2023 ] || [ -z "$unstable" ] && [ "$os_type" = "amzn" ]  ; then
-        printf "${RED}${os_real} ${os_version}${NORMAL} is not supported by stable installer${unstable_suffix}\\n"
+    opensuse-leap)
+      if [ "$os_major_version" -lt 15 ] || [ -z "$unstable" ] && [ "$os_type" = "opensuse-leap" ]  ; then
+        printf "${RED}${os_real} ${os_version}${NORMAL} is not supported by this installer${unstable_suffix}\\n"
         exit 1
       fi
       ;;

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -902,6 +902,12 @@ install_virtualmin_release() {
         exit 1
       fi
       ;;
+    amzn)
+      if [ "$os_version" -lt 2023 ] || [ -z "$unstable" ] && [ "$os_type" = "amzn" ]  ; then
+        printf "${RED}${os_real} ${os_version}${NORMAL} is not supported by stable installer${unstable_suffix}\\n"
+        exit 1
+      fi
+      ;;
     *)
       printf "${RED}This OS/version is not recognized! Cannot continue!${NORMAL}\\n"
       exit 1


### PR DESCRIPTION
This PR adds support for openSUSE.

It also requires updates for Webmin, and Virtualmin Nginx and Virtualmin Config modules.

Also, it adds an explicit warning message before installing to all Grade B systems, e.g.:

<img width="745" alt="image" src="https://github.com/virtualmin/virtualmin-install/assets/4426533/86076bcb-7370-4538-814e-a17d98e1b0c3">
