### PR TITLE
Add numerous improvements to Virtualmin install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,15 @@ The **Grade A** systems currently supported by install script are:
 The _Grade B_ systems currently supported by install script are:
 
     Red Hat Enterprise Linux and derivatives
-      - Fedora Server 38 on x86_64
-      - Amazon Linux 2023 on x86_64
+      - Fedora Server 38+ on x86_64
       - CentOS Stream 8 and 9 on x86_64
       - Oracle Linux 8 and 9 on x86_64
       - CloudLinux 8 and 9 on x86_64
+      - Amazon Linux 2023+ on x86_64
+      - openSUSE Server 15 on x86_64
   
     Debian Linux and derivatives
-      - Kali Linux Rolling on x86_64
+      - Kali Linux Rolling 2023+ on x86_64
 
 We strongly recommend you use the latest version of your preferred **Grade A** supported distribution. The latest release gets the most active testing and bug fixing.
 

--- a/opensuse.sh
+++ b/opensuse.sh
@@ -6,7 +6,6 @@
 opensuse_poststack() {
     # Install Virtualmin Config package manually
     # as it currently fails with false positive error
-    echo "Hello im module $module_name -- $install_group_opts"
     package_virtualmin_config=$(dnf download virtualmin-config)
     package_virtualmin_config_name=$(echo "$package_virtualmin_config" | grep -o 'virtualmin-config[^ ]*.rpm')
     rpm -U --nodeps --replacepkgs --replacefiles --quiet $package_virtualmin_config_name

--- a/opensuse.sh
+++ b/opensuse.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
-# Copyright 2005-2023 Virtualmin, Inc.
-# virtualmin-install.sh - openSUSE module
 # shellcheck disable=SC2154 disable=SC2034 disable=SC2086
+# Copyright 2005-2023 Virtualmin, Inc.
+# virtualmin-install.sh - openSUSE module v1.0.0
 
 # Fix openSUSE pitfalls
 opensuse_poststack() {

--- a/opensuse.sh
+++ b/opensuse.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 # Copyright 2005-2023 Virtualmin, Inc.
 # virtualmin-install.sh - openSUSE module
+# shellcheck disable=SC2154 disable=SC2034 disable=SC2086
 
 # Fix openSUSE pitfalls
 opensuse_poststack() {

--- a/opensuse.sh
+++ b/opensuse.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# Copyright 2005-2023 Virtualmin, Inc.
+# virtualmin-install.sh - openSUSE module
+
+# Fix openSUSE pitfalls
+opensuse_poststack() {
+    # Install Virtualmin Config package manually
+    # as it currently fails with false positive error
+    echo "Hello im module $module_name -- $install_group_opts"
+    package_virtualmin_config=$(dnf download virtualmin-config)
+    package_virtualmin_config_name=$(echo "$package_virtualmin_config" | grep -o 'virtualmin-config[^ ]*.rpm')
+    rpm -U --nodeps --replacepkgs --replacefiles --quiet $package_virtualmin_config_name
+    # Create symlink to known @INC to where Virtualmin Config is actually is
+    ln -sf /usr/share/perl5/vendor_perl/Virtualmin /usr/lib/perl5/site_perl
+    # Remove downloaded package
+    rm -f $package_virtualmin_config_name
+    # Now check which packages are missing and install them manually using package manager
+    install_group_opts_loud=$(echo $install_group_opts | sed 's/ --quiet//g')
+    virtualmin_group_missing_cmd="$install_cmd $install_group_opts_loud $rhgroup"
+    virtualmin_group_missing_try=$(eval $virtualmin_group_missing_cmd 2>&1)
+    # Extract missing package list
+    virtualmin_group_missing=$(echo "$virtualmin_group_missing_try" | grep -o '"[^"]\+"' | tr -d '"' | tr '\n' ' ')
+    # PHP packages are actually named php8-* in openSUSE
+    virtualmin_group_missing=$(echo "$virtualmin_group_missing" | sed 's/php-/php8-/g')
+    # The package fail2ban-firewalld is named fail2ban in openSUSE
+    virtualmin_group_missing=$(echo "$virtualmin_group_missing" | sed 's/fail2ban-firewalld/fail2ban/g')
+    # The package mod_fcgid is named apache2-mod_fcgid in openSUSE
+    virtualmin_group_missing=$(echo "$virtualmin_group_missing" | sed 's/mod_fcgid/apache2-mod_fcgid/g')
+    # AppArmor should either be configured to allow /var/php-fpm for
+    # PHP-FPM sockets or disabled completely
+    systemctl stop apparmor.service
+    systemctl disable apparmor.service
+    systemctl mask apparmor.service
+    # Swap pre-installed posfix for postfix-bdb-lmdb
+    $install_cmd -y swap --allowerasing postfix postfix-bdb-lmdb
+    # Install missing packages that we extracted earlier
+    $install --skip-broken $virtualmin_group_missing cyrus-sasl-saslauthd
+    # There is no AWStats package in openSUSE
+    $install_cmd -y remove wbm-virtualmin-awstats
+    # Add allow_vendor_change=True to /etc/dnf/dnf.conf unless it's already there
+    grep -qxF 'allow_vendor_change=True' /etc/dnf/dnf.conf || echo "allow_vendor_change=True" >> /etc/dnf/dnf.conf
+}
+run_ok "opensuse_poststack" "Installing Virtualmin $vm_version missing stack packages"
+# Don't show false positively skipped packages
+noskippedpackagesforce=1
+# Fix to skip configuring AWStats as it's not available in openSUSE
+virtualmin_config_system_excludes=" --exclude AWStats"

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -571,6 +571,35 @@ if [ "$skipyesno" -ne 1 ] && [ -z "$setup_only" ]; then
   install_msg
 fi
 
+os_unstable_pre_check() {
+  if [ -n "$unstable" ]; then
+    cat <<EOF
+
+  ${YELLOWBG}${BLACK}${BOLD} INSTALLATION WARNING! ${NORMAL}
+
+  You are about to install Virtualmin $PRODUCT on a ${BOLD}Grade B${NORMAL} operating system. Please
+  be advised that this OS version is not recommended for servers, and may have
+  bugs that could affect the performance and stability of the system.
+
+  Certain features may not work as intended or might be unavailable on this OS.
+
+EOF
+    if [ "$os_type" = "opensuse-leap" ]; then
+      cat <<EOF
+  For installation to work on ${UNDERLINE}${BOLD}openSUSE${NORMAL} it is required to set up NetworkManager
+  as default network configuration tool during the initial OS installation pha-
+  se. Furthermore, you will need to set up the DNF package manager using the
+  instructions provided in this tutorial: ${UNDERLINE}https://en.opensuse.org/SDB:DNF${NORMAL}
+
+EOF
+    fi
+    printf " Continue? (y/n) "
+    if ! yesno; then
+      exit
+    fi
+  fi
+}
+
 preconfigured_system_msg() {
   # Double check if installed, just in case above error ignored.
   is_preconfigured_rs=$(is_preconfigured)
@@ -623,6 +652,7 @@ EOF
   fi
 }
 if [ "$skipyesno" -ne 1 ] && [ -z "$setup_only" ]; then
+  os_unstable_pre_check
   preconfigured_system_msg
   already_installed_msg
 fi

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -23,7 +23,8 @@ vm_version=7
 
 # Server
 upgrade_virtualmin_host=software.virtualmin.com
-upgrade_virtualmin_host_mods="$upgrade_virtualmin_host/lib/mods"
+upgrade_virtualmin_host_lib="$upgrade_virtualmin_host/lib"
+upgrade_virtualmin_host_mods="$upgrade_virtualmin_host_lib/mods"
 
 # Currently supported systems
 # https://www.virtualmin.com/os-support/
@@ -295,7 +296,7 @@ download_slib() {
   else
     # We need HTTP client first
     pre_check_http_client
-    $download "https://$upgrade_virtualmin_host/lib/slib.sh" >>"$log" 2>&1
+    $download "https://$upgrade_virtualmin_host_lib/slib.sh" >>"$log" 2>&1
     if [ $? -ne 0 ]; then
       echo "Error: Failed to download utility function library. Cannot continue. Check your network connection and DNS settings."
       exit 1
@@ -1138,10 +1139,10 @@ install_virtualmin_release() {
 
     # Install our keys
     log_debug "Installing Webmin and Virtualmin package signing keys .."
-    download "https://$upgrade_virtualmin_host/lib/RPM-GPG-KEY-virtualmin-$vm_version" "Downloading Virtualmin $vm_version key"
+    download "https://$upgrade_virtualmin_host_lib/RPM-GPG-KEY-virtualmin-$vm_version" "Downloading Virtualmin $vm_version key"
     run_ok "gpg --import RPM-GPG-KEY-virtualmin-$vm_version && cat RPM-GPG-KEY-virtualmin-$vm_version | gpg --dearmor > /usr/share/keyrings/$repoid_debian_like-virtualmin-$vm_version.gpg" "Installing Virtualmin $vm_version key"
     if [ "$vm6_repos" -eq 1 ]; then
-      download "https://$upgrade_virtualmin_host/lib/RPM-GPG-KEY-webmin" "Downloading Webmin key"
+      download "https://$upgrade_virtualmin_host_lib/RPM-GPG-KEY-webmin" "Downloading Webmin key"
       run_ok "gpg --import RPM-GPG-KEY-webmin && cat RPM-GPG-KEY-webmin | gpg --dearmor > /usr/share/keyrings/$repoid_debian_like-webmin.gpg" "Installing Webmin key"
     fi
     run_ok "apt-get update" "Downloading repository metadata"

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -232,6 +232,9 @@ if [ -z "$VIRTUALMIN_INSTALL_TEMPDIR" ]; then
   mkdir "$VIRTUALMIN_INSTALL_TEMPDIR"
 fi
 
+# Export temp directory for Virtualmin Config
+export VIRTUALMIN_INSTALL_TEMPDIR
+
 # "files" subdir for libs
 mkdir "$VIRTUALMIN_INSTALL_TEMPDIR/files"
 srcdir="$VIRTUALMIN_INSTALL_TEMPDIR/files"

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -277,18 +277,22 @@ pre_check_http_client() {
 }
 
 download_slib() {
-  # We need HTTP client first
-  pre_check_http_client
-
+  # If slib.sh is available locally in the same directory use it
+  if [ -f "$pwd/slib.sh" ]; then
+    chmod +x "$pwd/slib.sh"
+    . "$pwd/slib.sh"
   # Download the slib (source: http://github.com/virtualmin/slib)
-  $download "https://$upgrade_virtualmin_host/lib/slib.sh" >>"$log" 2>&1
-  if [ $? -ne 0 ]; then
-    echo "Error: Failed to download utility function library. Cannot continue. Check your network connection and DNS settings."
-    exit 1
+  else
+    # We need HTTP client first
+    pre_check_http_client
+    $download "https://$upgrade_virtualmin_host/lib/slib.sh" >>"$log" 2>&1
+    if [ $? -ne 0 ]; then
+      echo "Error: Failed to download utility function library. Cannot continue. Check your network connection and DNS settings."
+      exit 1
+    fi
+    chmod +x slib.sh
+    . ./slib.sh
   fi
-  chmod +x slib.sh
-  # shellcheck disable=SC1091
-  . ./slib.sh
 }
 
 # Utility function library

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -864,15 +864,16 @@ if [ "$(id -u)" -ne 0 ]; then
   fi
 fi
 
-if [ -n "$setup_only" ]; then
-  # Force CentOS 7 to get older repos because of custom Apache
-  if [ "$os_type" = "centos" ] && [ "$os_major_version" -eq 7 ]; then
-    if [ "$SERIAL" != "GPL" ]; then
-      repopath=""
-    fi
-    vm_version=6
-    vm6_repos=1
+# Force CentOS 7 to get older repos because of custom Apache
+if [ "$os_type" = "centos" ] && [ "$os_major_version" -eq 7 ]; then
+  if [ "$SERIAL" != "GPL" ]; then
+    repopath=""
   fi
+  vm_version=6
+  vm6_repos=1
+fi
+
+if [ -n "$setup_only" ]; then
   pre_check_perl
   pre_check_http_client
   pre_check_gpg

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -1031,6 +1031,14 @@ install_virtualmin_release() {
     fi
     # Remove any existing repo config, in case it's a reinstall
     remove_virtualmin_release
+    
+    # Set correct keys name for Debian vs derivatives
+    repoid_debian_like=debian
+    if [ -n "${os_type}" ]; then
+      repoid_debian_like="${os_type}"
+    fi
+
+    # Setup repo file
     apt_auth_dir='/etc/apt/auth.conf.d'
     LOGINREAL=$LOGIN
     if [ -d "$apt_auth_dir" ]; then
@@ -1040,12 +1048,13 @@ install_virtualmin_release() {
       fi
     fi
     for repo in $repos; do
-      printf "deb [signed-by=/usr/share/keyrings/debian-virtualmin-$vm_version.gpg] https://${LOGINREAL}$upgrade_virtualmin_host/vm/${vm_version}/${repopath}apt ${repo} main\\n" >/etc/apt/sources.list.d/virtualmin.list
+      printf "deb [signed-by=/usr/share/keyrings/$repoid_debian_like-virtualmin-$vm_version.gpg] https://${LOGINREAL}$upgrade_virtualmin_host/vm/${vm_version}/${repopath}apt ${repo} main\\n" >/etc/apt/sources.list.d/virtualmin.list
     done
 
     # Install our keys
     log_debug "Installing Webmin and Virtualmin package signing keys .."
     download "https://$upgrade_virtualmin_host/lib/RPM-GPG-KEY-virtualmin-$vm_version" "Downloading Virtualmin $vm_version key"
+    run_ok "gpg --import RPM-GPG-KEY-virtualmin-$vm_version && cat RPM-GPG-KEY-virtualmin-$vm_version | gpg --dearmor > /usr/share/keyrings/$repoid_debian_like-virtualmin-$vm_version.gpg" "Installing Virtualmin $vm_version key"
     if [ "$vm6_repos" -eq 1 ]; then
       download "https://$upgrade_virtualmin_host/lib/RPM-GPG-KEY-webmin" "Downloading Webmin key"
       run_ok "gpg --import RPM-GPG-KEY-webmin && cat RPM-GPG-KEY-webmin | gpg --dearmor > /usr/share/keyrings/$repoid_debian_like-webmin.gpg" "Installing Webmin key"

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -339,6 +339,16 @@ log_fatal() {
   log_error "$1"
 }
 
+# Test if grade B system
+grade_b_system() {
+  case "$os_type" in
+  rhel | centos | rocky | almalinux | debian | ubuntu)
+    return 0
+    ;;
+  esac
+  return 1
+}
+
 remove_virtualmin_release() {
   case "$os_type" in
   rhel | fedora | centos | centos_stream | rocky | almalinux | ol | cloudlinux | amzn | opensuse-leap)
@@ -663,7 +673,10 @@ EOF
   fi
 }
 if [ "$skipyesno" -ne 1 ] && [ -z "$setup_only" ]; then
-  os_unstable_pre_check
+  grade_b_system
+  if [ $? -eq 1 ]; then
+    os_unstable_pre_check
+  fi
   preconfigured_system_msg
   already_installed_msg
 fi

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -303,6 +303,9 @@ download_slib # for production this block
               # minus its header
 ##########################################
 
+# Get OS type
+get_distro
+
 # Check the serial number and key
 serial_ok "$SERIAL" "$KEY"
 # Setup slog
@@ -835,7 +838,6 @@ chmod 700 /etc/virtualmin-license
 cd ..
 
 # Populate some distro version globals
-get_distro
 log_debug "Operating system name:    $os_real"
 log_debug "Operating system version: $os_version"
 log_debug "Operating system type:    $os_type"

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -23,7 +23,7 @@ vm_version=7
 
 # Server
 upgrade_virtualmin_host=software.virtualmin.com
-upgrade_virtualmin_host_mods="$upgrade_virtualmin_host/mods"
+upgrade_virtualmin_host_mods="$upgrade_virtualmin_host/lib/mods"
 
 # Currently supported systems
 # https://www.virtualmin.com/os-support/

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -962,26 +962,28 @@ install_virtualmin_release() {
     fi
     package_type="rpm"
     if command -pv dnf 1>/dev/null 2>&1; then
-      install="dnf -y install"
-      update="dnf -y update"
       install_cmd="dnf"
-      install_group="dnf -y --quiet --skip-broken group install --setopt=group_package_types=mandatory,default"
-      install_config_manager="dnf config-manager"
+      install="$install_cmd -y install"
+      update="$install_cmd -y update"
+      install_group_opts="-y --quiet --skip-broken group install --setopt=group_package_types=mandatory,default"
+      install_group="$install_cmd $install_group_opts"
+      install_config_manager="$install_cmd config-manager"
       # Do not use package manager when fixing repos
       if [ -z "$setup_only" ]; then
         run_ok "$install dnf-plugins-core" "Installing core plugins for package manager"
       fi
     else
-      install="/usr/bin/yum -y install"
-      update="/usr/bin/yum -y update"
-      install_cmd="/usr/bin/yum"
+      install_cmd="yum"
+      install="$install_cmd -y install"
+      update="$install_cmd -y update"
       if [ "$os_major_version" -ge 7 ]; then
         # Do not use package manager when fixing repos
         if [ -z "$setup_only" ]; then
-          run_ok "yum --quiet groups mark convert" "Updating groups metadata"
+          run_ok "$install_cmd --quiet groups mark convert" "Updating groups metadata"
         fi
       fi
-      install_group="yum -y --quiet --skip-broken groupinstall --setopt=group_package_types=mandatory,default"
+      install_group_opts="-y --quiet --skip-broken groupinstall --setopt=group_package_types=mandatory,default"
+      install_group="$install_cmd $install_group_opts"
       install_config_manager="yum-config-manager"
     fi
 

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# shellcheck disable=SC2059 disable=SC2181 disable=SC2154 disable=SC2317 disable=SC3043 disable=SC2086 disable=SC2039 disable=SC2034 disable=SC2089 disable=SC2090 disable=SC1091 disable=SC2164 disable=SC1090
+# shellcheck disable=SC2059 disable=SC2181 disable=SC2154 disable=SC2317 disable=SC3043 disable=SC2086 disable=SC2039 disable=SC2034 disable=SC2089 disable=SC2090 disable=SC1091 disable=SC1090
 # virtualmin-install.sh
 # Copyright 2005-2023 Virtualmin, Inc.
 # Simple script to grab the virtualmin-release and virtualmin-base packages.
@@ -235,11 +235,15 @@ fi
 # "files" subdir for libs
 mkdir "$VIRTUALMIN_INSTALL_TEMPDIR/files"
 srcdir="$VIRTUALMIN_INSTALL_TEMPDIR/files"
-if ! cd "$srcdir"; then
-  echo "Error: Failed to enter $srcdir temporary directory"
-  exit 1
-fi
-export VIRTUALMIN_INSTALL_TEMPDIR
+
+# Switch to temp directory or exit with error
+goto_tmpdir() {
+  if ! cd "$srcdir" >>"$log" 2>&1; then
+    echo "Error: Failed to enter $srcdir temporary directory"
+    exit 1
+  fi
+}
+goto_tmpdir
 
 pre_check_http_client() {
   # Check for wget or curl or fetch
@@ -455,7 +459,7 @@ uninstall() {
   fi
 
   # Go to the temp directory
-  cd "$srcdir"
+  goto_tmpdir
 
   # Uninstall packages
   uninstall_packages()

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -813,6 +813,9 @@ log_debug "virtualmin-install.sh version: $VER"
 if [ -z "$setup_only" ]; then
   log_debug "Checking for fully qualified hostname .."
   name="$(hostname -f)"
+  if [ $? -ne 0 ]; then
+    name=$(hostnamectl --static)
+  fi
   if [ -n "$forcehostname" ]; then
     set_hostname "$forcehostname"
   elif ! is_fully_qualified "$name"; then

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -1279,7 +1279,7 @@ fi
 
 # We want to make sure we're running our version of packages if we have
 # our own version.  There's no good way to do this, but we'll
-run_ok "$install_updates" "Installing Virtualmin $vm_version and all related packages updates"
+run_ok "$install_updates" "Installing Virtualmin $vm_version related packages updates"
 if [ "$?" != "0" ]; then
   errorlist="${errorlist}  ${YELLOW}◉${NORMAL} Installing updates returned an error.\\n"
   errors=$((errors + 1))

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -898,7 +898,7 @@ install_virtualmin_release() {
   # Grab virtualmin-release from the server
   log_debug "Configuring package manager for ${os_real} ${os_version} .."
   case "$os_type" in
-  rhel | centos | centos_stream | rocky | almalinux | ol | cloudlinux | amzn | fedora)
+  rhel | fedora | centos | centos_stream | rocky | almalinux | ol | cloudlinux | amzn | opensuse-leap)
     case "$os_type" in
     rhel | centos | centos_stream)
       if [ "$os_type" = "centos_stream" ]; then
@@ -1386,7 +1386,7 @@ disable_selinux() {
 
 # Changes that are specific to OS
 case "$os_type" in
-"fedora" | "centos" | "centos_stream" | "rhel" | "rocky" | "almalinux" | "ol" | "cloudlinux")
+rhel | fedora | centos | centos_stream | rocky | almalinux | ol | cloudlinux | amzn)
   disable_selinux
   ;;
 esac

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -941,6 +941,12 @@ install_virtualmin_release() {
         exit 1
       fi
       ;;
+    amzn)
+      if [ "$os_version" -lt 2023 ] || [ -z "$unstable" ] && [ "$os_type" = "amzn" ]  ; then
+        printf "${RED}${os_real} ${os_version}${NORMAL} is not supported by stable installer${unstable_suffix}\\n"
+        exit 1
+      fi
+      ;;
     *)
       printf "${RED}This OS/version is not recognized! Cannot continue!${NORMAL}\\n"
       exit 1

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -27,18 +27,11 @@ upgrade_virtualmin_host=software.virtualmin.com
 # Currently supported systems
 # https://www.virtualmin.com/os-support/
 
-# Store new log each time
-log=/root/virtualmin-install.log
-if [ -e "$log" ]; then
-  while true; do
-    logcnt=$((logcnt+1))
-    logold="$log.$logcnt"
-    if [ ! -e "$logold" ]; then
-      mv $log $logold
-      break
-    fi
-  done
-fi
+# Save current working directory
+pwd="$PWD"
+
+# Set log type
+log_type="virtualmin-install"
 
 # Set defaults
 bundle='LAMP' # Other option is LEMP
@@ -140,6 +133,7 @@ while [ "$1" != "" ]; do
   --uninstall | -u)
     shift
     mode="uninstall"
+    log_type="virtualmin-uninstall"
     ;;
   *)
     printf "Unrecognized option: $1\\n\\n"
@@ -148,6 +142,19 @@ while [ "$1" != "" ]; do
     ;;
   esac
 done
+
+# Store new log each time
+log="$pwd/$log_type.log"
+if [ -e "$log" ]; then
+  while true; do
+    logcnt=$((logcnt+1))
+    logold="$log.$logcnt"
+    if [ ! -e "$logold" ]; then
+      mv $log $logold
+      break
+    fi
+  done
+fi
 
 # If Pro user downloads GPL version of `install.sh` script
 # to fix repos check if there is an active license exists

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -1315,7 +1315,7 @@ yum_check_skipped() {
       skippedpackagesnum=$((skippedpackagesnum+1))
     fi
   done < "$log"
-  if [ "$skippedpackages" != "" ]; then
+  if [ -z "$noskippedpackagesforce" ] && [ "$skippedpackages" != "" ]; then
     if [ "$skippedpackagesnum" != 1 ]; then
       ts="s"
     fi

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -106,16 +106,6 @@ while [ "$1" != "" ]; do
     setup_only=1
     mode='setup'
     unstable='unstable'
-    case "$1" in
-    force-latest)
-      shift
-      setup_only_force_latest=1
-      ;;
-    *)
-      setup_only_force_latest=0
-      ;;
-    esac
-    break
     ;;
   --hostname | -n)
     shift

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# shellcheck disable=SC2059 disable=SC2181 disable=SC2154 disable=SC2317 disable=SC3043 disable=SC2086 disable=SC2039 disable=SC2034
+# shellcheck disable=SC2059 disable=SC2181 disable=SC2154 disable=SC2317 disable=SC3043 disable=SC2086 disable=SC2039 disable=SC2034 disable=SC2089 disable=SC2090 disable=SC1091 disable=SC2164
 # virtualmin-install.sh
 # Copyright 2005-2023 Virtualmin, Inc.
 # Simple script to grab the virtualmin-release and virtualmin-base packages.

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -18,7 +18,7 @@
 # License and version
 SERIAL=GPL
 KEY=GPL
-VER=7.1.2
+VER=7.2.0
 vm_version=7
 
 # Server

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -221,22 +221,22 @@ if [ -n "$TMPNOEXEC" ]; then
   exit 1
 fi
 
-if [ -z "$VMITMPDIR" ]; then
-  VMITMPDIR="$TMPDIR/.virtualmin-$$"
-  if [ -e "$VMITMPDIR" ]; then
-    rm -rf "$VMITMPDIR"
+if [ -z "$VIRTUALMIN_INSTALL_TEMPDIR" ]; then
+  VIRTUALMIN_INSTALL_TEMPDIR="$TMPDIR/.virtualmin-$$"
+  if [ -e "$VIRTUALMIN_INSTALL_TEMPDIR" ]; then
+    rm -rf "$VIRTUALMIN_INSTALL_TEMPDIR"
   fi
-  mkdir "$VMITMPDIR"
+  mkdir "$VIRTUALMIN_INSTALL_TEMPDIR"
 fi
 
 # "files" subdir for libs
-mkdir "$VMITMPDIR/files"
-srcdir="$VMITMPDIR/files"
+mkdir "$VIRTUALMIN_INSTALL_TEMPDIR/files"
+srcdir="$VIRTUALMIN_INSTALL_TEMPDIR/files"
 if ! cd "$srcdir"; then
   echo "Error: Failed to enter $srcdir temporary directory"
   exit 1
 fi
-export VMITMPDIR
+export VIRTUALMIN_INSTALL_TEMPDIR
 
 pre_check_http_client() {
   # Check for wget or curl or fetch
@@ -330,8 +330,8 @@ remove_virtualmin_release() {
     rm -f /etc/pki/rpm-gpg/RPM-GPG-KEY-webmin
     ;;
   "debian" | "ubuntu")
-    grep -v "virtualmin" /etc/apt/sources.list >"$VMITMPDIR"/sources.list
-    mv "$VMITMPDIR"/sources.list /etc/apt/sources.list
+    grep -v "virtualmin" /etc/apt/sources.list >"$VIRTUALMIN_INSTALL_TEMPDIR"/sources.list
+    mv "$VIRTUALMIN_INSTALL_TEMPDIR"/sources.list /etc/apt/sources.list
     rm -f /etc/apt/sources.list.d/virtualmin.list
     rm -f /etc/apt/auth.conf.d/virtualmin.conf
     rm -f /usr/share/keyrings/debian-virtualmin-*
@@ -345,9 +345,9 @@ fatal() {
   log_fatal "Fatal Error Occurred: $1"
   printf "${RED}Cannot continue installation.${NORMAL}\\n"
   remove_virtualmin_release
-  if [ -x "$VMITMPDIR" ]; then
+  if [ -x "$VIRTUALMIN_INSTALL_TEMPDIR" ]; then
     log_warning "Removing temporary directory and files."
-    rm -rf "$VMITMPDIR"
+    rm -rf "$VIRTUALMIN_INSTALL_TEMPDIR"
   fi
   log_fatal "If you are unsure of what went wrong, you may wish to review the log"
   log_fatal "in $log"
@@ -1297,8 +1297,8 @@ if [ "$mode" = "minimal" ]; then
 fi
 virtualmin-config-system --bundle "$bundle"$virtualmin_config_system_excludes
 # Log SSL request status, if available
-if [ -f "$VMITMPDIR/virtualmin_ssl_host_status" ]; then
-  virtualmin_ssl_host_status=$(cat "$VMITMPDIR/virtualmin_ssl_host_status")
+if [ -f "$VIRTUALMIN_INSTALL_TEMPDIR/virtualmin_ssl_host_status" ]; then
+  virtualmin_ssl_host_status=$(cat "$VIRTUALMIN_INSTALL_TEMPDIR/virtualmin_ssl_host_status")
   log_debug "$virtualmin_ssl_host_status"
 fi
 if [ "$?" != "0" ]; then
@@ -1331,17 +1331,17 @@ kill "$config_system_pid" 1>/dev/null 2>&1
 tput cnorm 1>/dev/null 2>&1
 
 # Was host default domain SSL request successful?
-if [ -d "$VMITMPDIR/virtualmin_ssl_host_success" ]; then
+if [ -d "$VIRTUALMIN_INSTALL_TEMPDIR/virtualmin_ssl_host_success" ]; then
   ssl_host_success=1
 fi
 
 # Cleanup the tmp files
 printf "${GREEN}▣▣▣${NORMAL} Cleaning up\\n"
-if [ "$VMITMPDIR" != "" ] && [ "$VMITMPDIR" != "/" ]; then
-  log_debug "Cleaning up temporary files in $VMITMPDIR."
-  find "$VMITMPDIR" -delete
+if [ "$VIRTUALMIN_INSTALL_TEMPDIR" != "" ] && [ "$VIRTUALMIN_INSTALL_TEMPDIR" != "/" ]; then
+  log_debug "Cleaning up temporary files in $VIRTUALMIN_INSTALL_TEMPDIR."
+  find "$VIRTUALMIN_INSTALL_TEMPDIR" -delete
 else
-  log_error "Could not safely clean up temporary files because TMPDIR set to $VMITMPDIR."
+  log_error "Could not safely clean up temporary files because TMPDIR set to $VIRTUALMIN_INSTALL_TEMPDIR."
 fi
 
 if [ -n "$QUOTA_FAILED" ]; then

--- a/virtualmin-install.sh
+++ b/virtualmin-install.sh
@@ -462,6 +462,12 @@ uninstall() {
     fi
   fi
 
+  # Log to file and tell the user nicely
+  log_info "Started uninstallation log in $log"
+
+  # Always sleep just a bit in case the user changes their mind
+  sleep 1
+
   # Go to the temp directory
   goto_tmpdir
 


### PR DESCRIPTION
This PR adds various improvements and bug-fixes, and also support for openSUSE as a separate module.


 * Fix to store install and uninstall logs separately
 * Fix to always setup Virtualmin 7 repos unless CentOS 7
 * Fix to set correct key name for Debian vs derivatives, i.e.:
    `/usr/share/keyrings/ubuntu-virtualmin-7.gpg` vs
    `/usr/share/keyrings/debian-virtualmin-7.gpg`
  * Add ability to use `slib.sh` from local file (if available - great for testing purposes)
  * Add `hostnamectl --static` as backup option
  * Add improvements to uninstall process
  * Add an automatic warning message display for all unstable OS (Grade B systems) before installation
    <img width="600" alt="image" src="https://github.com/virtualmin/virtualmin-install/assets/4426533/86076bcb-7370-4538-814e-a17d98e1b0c3">
  * Add openSUSE support in a separate downloadable module
  * Fix to drop `--unstable` flag in favor of automatic detection and listing of unstable OS (Grade B systems)
  